### PR TITLE
Depend on perl v5.10 not v5.100

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -16,8 +16,8 @@ Module::Build -> new
  },
  requires =>
  {
-   perl                => 5.10,
- 	warnings            => 1.12
+   perl                => '5.10.0',
+ 	warnings            => '1.12'
  },
  meta_merge =>
  {


### PR DESCRIPTION
Perl versions are weird - http://blogs.perl.org/users/grinnz/2018/04/a-guide-to-versions-in-perl.html

5.10 is the same as 5.1 and actually means v5.100. Either write v5.10 or 5.10.0 to actually depend on the right version.

$ perl -E 'say version->parse($_)->normal for qw/5.1 5.10 5.10.0 v5.10/'
v5.100.0
v5.100.0
v5.10.0
v5.10.0